### PR TITLE
Correctly calculate HTTP2 response body size

### DIFF
--- a/okhttp/src/main/java/okhttp3/internal/http2/Http2ExchangeCodec.kt
+++ b/okhttp/src/main/java/okhttp3/internal/http2/Http2ExchangeCodec.kt
@@ -27,6 +27,7 @@ import okhttp3.internal.http.ExchangeCodec
 import okhttp3.internal.http.RequestLine
 import okhttp3.internal.http.StatusLine
 import okhttp3.internal.http.StatusLine.Companion.HTTP_CONTINUE
+import okhttp3.internal.http.promisesBody
 import okhttp3.internal.http2.Header.Companion.RESPONSE_STATUS_UTF8
 import okhttp3.internal.http2.Header.Companion.TARGET_AUTHORITY
 import okhttp3.internal.http2.Header.Companion.TARGET_AUTHORITY_UTF8
@@ -106,7 +107,10 @@ class Http2ExchangeCodec(
   }
 
   override fun reportedContentLength(response: Response): Long {
-    return response.headersContentLength()
+    return when {
+      !response.promisesBody() -> 0L
+      else -> response.headersContentLength()
+    }
   }
 
   override fun openResponseBodySource(response: Response): Source {

--- a/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
+++ b/okhttp/src/test/java/okhttp3/internal/http2/HttpOverHttp2Test.java
@@ -187,6 +187,53 @@ public final class HttpOverHttp2Test {
         (server.getHostName() + ":" + server.getPort()));
   }
 
+  @Test public void get204Response() throws Exception {
+    MockResponse responseWithoutBody = new MockResponse();
+    responseWithoutBody.status("HTTP/1.1 204");
+    responseWithoutBody.removeHeader("Content-Length");
+    server.enqueue(responseWithoutBody);
+
+    Call call = client.newCall(new Request.Builder()
+        .url(server.url("/foo"))
+        .build());
+    Response response = call.execute();
+
+    // Body contains nothing.
+    assertThat(response.body().bytes().length).isEqualTo(0);
+    assertThat(response.body().contentLength()).isEqualTo(0);
+
+    // Content-Length header doesn't exist in a 204 response.
+    assertThat(response.header("content-length")).isNull();
+
+    assertThat(response.code()).isEqualTo(204);
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getRequestLine()).isEqualTo("GET /foo HTTP/1.1");
+  }
+
+  @Test public void head() throws Exception {
+    MockResponse mockResponse = new MockResponse().setHeader("Content-Length", 5);
+    mockResponse.status("HTTP/1.1 200");
+    server.enqueue(mockResponse);
+
+    Call call = client.newCall(new Request.Builder()
+        .head()
+        .url(server.url("/foo"))
+        .build());
+
+    Response response = call.execute();
+
+    // Body contains nothing.
+    assertThat(response.body().bytes().length).isEqualTo(0);
+    assertThat(response.body().contentLength()).isEqualTo(0);
+
+    // Content-Length header stays correctly.
+    assertThat(response.header("content-length")).isEqualTo("5");
+
+    RecordedRequest request = server.takeRequest();
+    assertThat(request.getRequestLine()).isEqualTo("HEAD /foo HTTP/1.1");
+  }
+
   @Test public void emptyResponse() throws IOException {
     server.enqueue(new MockResponse());
 


### PR DESCRIPTION
Currently response body size is determined by Content-Length header value, i.e. we use the header value if it exists, otherwise set -1.

This doesn't work for some HTTP responses. For example, `response.body().contentLength()` should return 0 for a response of HEAD request instead of using the Content-Length value. Also it should return 0 for a 204 responses instead of providing -1 when Content-Length header is not present.